### PR TITLE
Fix arm night

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ class ADCPlatform {
         silentArming: false
       },
       'night': {
+        nightArming: true,
         noEntryDelay: false,
         silentArming: true
       },
@@ -492,7 +493,7 @@ class ADCPlatform {
         opts.silentArming = this.armingModes.stay.silentArming;
         break
       case Characteristic.SecuritySystemTargetState.NIGHT_ARM:
-        method = nodeADC.armStay
+        method = nodeADC.armNightStay
         opts.noEntryDelay = this.armingModes.night.noEntryDelay;
         opts.silentArming = this.armingModes.night.silentArming;
         break


### PR DESCRIPTION
Fixed broken night arming, when using home-bridge to arm the alarm.com system, instead of going into night mode it goes into regular arm stay, this fixes that. Tested on two separate installs with two separate alarm.com systems/logins.  This is part 1/2 to fix the issue.

Dependent on: https://github.com/node-alarm-dot-com/node-alarm-dot-com/pull/14