### PR TITLE
Improve logging of unknown sensors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -557,7 +557,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
 
     const [type, characteristic, model] = getSensorType(sensor);
     if (type === undefined) {
-      this.log.warn(`Warning: Sensor with unknown state ${sensor.attributes.state}`);
+      this.log.warn(`Warning: Sensor ${sensor.attributes.description} has unknown state ${sensor.attributes.state} (${sensor.id})`);
 
       return;
     }


### PR DESCRIPTION
This change will enable users to identify which sensor they have that is currently unsupported by including the description of the sensor from Alarm.com. This description should be a user friendly description that they are familiar with from their Alarm.com application. By including the ID on the logging will also enable users to add those ID's to the list of ignored devices.

Example of logging:
[3/28/2021, 7:28:07 AM] [Security System] Warning: Sensor Front Bedroom Glass Break has unknown state 0 (#######-##)