### PR TITLE
Update timerLoop() variable factor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
    */
   timerLoop() {
     // Create a randomized delay by adding between 0 - 5 minutes to timer
-    const timerDelay = (this.config.pollTimeoutSeconds * 1000) + (300000 * Math.random());
+    const timerDelay = (this.config.pollTimeoutSeconds * 1000) + (30000 * Math.random());
     setTimeout(() => {
       this.refreshDevices();
       this.timerLoop();


### PR DESCRIPTION
Reduce timerLoop() variable factor from 300000 to 30000. Variable factor was too large which can result in a Alarm.com sample being performed after account Authorization has expired. If sample occurs after Authorization has expired the ECONRESET error can result.

The variable factor was introduced in beta-6 and was why beta-4 did not produce errors.