### PR TITLE
v1.7.2-beta.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-node-alarm-dot-com",
-  "version": "1.7.3-beta.5",
-  "betaVersion": "1.7.3",
+  "version": "1.7.2-beta.11",
+  "betaVersion": "1.7.2",
   "description": "Alarm.com plugin for Homebridge using Node.js",
   "author": {
     "name": "Mike Kormendy",
@@ -49,8 +49,8 @@
     "homebridge": ">=0.4.21"
   },
   "dependencies": {
-    "node-alarm-dot-com": "^1.11.0-beta.7",
-    "node-fetch": "^2.6.1",
+    "node-alarm-dot-com": "^1.11.0-beta.6",
+    "node-fetch": "^3.0.0-beta.9",
     "polling-to-event": "^2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-node-alarm-dot-com",
-  "version": "1.7.1",
-  "betaVersion": "1.7.2",
+  "version": "1.7.3-beta.5",
+  "betaVersion": "1.7.3",
   "description": "Alarm.com plugin for Homebridge using Node.js",
   "author": {
     "name": "Mike Kormendy",
@@ -49,18 +49,19 @@
     "homebridge": ">=0.4.21"
   },
   "dependencies": {
-    "node-alarm-dot-com": "^1.11.0-beta.6",
+    "node-alarm-dot-com": "^1.11.0-beta.7",
+    "node-fetch": "^2.6.1",
     "polling-to-event": "^2.1.0"
   },
   "devDependencies": {
-    "@types/node": "^15.12.4",
-    "@typescript-eslint/eslint-plugin": "^4.28.0",
-    "@typescript-eslint/parser": "^4.28.0",
-    "eslint": "^7.29.0",
+    "@types/node": "^15.14.2",
+    "@typescript-eslint/eslint-plugin": "^4.28.2",
+    "@typescript-eslint/parser": "^4.28.2",
+    "eslint": "^7.30.0",
     "homebridge": "^1.3.4",
-    "nodemon": "^2.0.7",
+    "nodemon": "^2.0.12",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.3.4"
+    "typescript": "^4.3.5"
   }
 }


### PR DESCRIPTION
Update provides recovery from `refreshDevices()` error by causing Alarm.com login on next timer loop.
- Changed `login()` to `loginSession` to avoid confusion with `login` in `node-alarm-dot-com` node_module.
- Reformat `loginSession()` as `async function` with error reporting.
- Syntactical TS updates flagged by VS Code.
- Using node-fetch `v3.00-beta.9`
