### PR TITLE
Use nightArming option instead of aliasing silentArming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -559,13 +559,13 @@ class ADCPlatform implements DynamicPlatformPlugin {
         method = armStay;
         opts.noEntryDelay = this.armingModes.stay.noEntryDelay;
         opts.silentArming = this.armingModes.stay.silentArming;
-        opts.silentArming = this.armingModes.stay.nightArming;
+        opts.nightArming = this.armingModes.stay.nightArming;
         break;
       case Characteristic.SecuritySystemTargetState.NIGHT_ARM:
         method = armStay;
         opts.noEntryDelay = this.armingModes.night.noEntryDelay;
         opts.silentArming = this.armingModes.night.silentArming;
-        opts.silentArming = this.armingModes.night.nightArming;
+        opts.nightArming = this.armingModes.night.nightArming;
         break;
       case Characteristic.SecuritySystemTargetState.AWAY_ARM:
         method = armAway;


### PR DESCRIPTION
Previously `silentArming` was used as a proxy for actually using `nightArming`.  However, devices do have native support for this.  In fact, using `silentArming` did not allow me to use `nightArming` with my DSC keypad.  I considered changing the line that was setting `silentArming` to use an or conditional with night arming to maintain backwards compatibility.  However, this would continue to cause anyone who had a keypad that wouldn't allow `silentArming` with `nightArming` to continue to fail.

Verified this using an actual keypad.  It would silently fail (hah) before and now succeeds to arm to night mode successfully.

Note that anyone who was relying on this unexpected behavior may see a change moving forward.  If this is a concern some sort of legacy flag can be implemented if needed.