### PR TITLE
Add thermostat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ This is a plugin for Homebridge, allowing communication with Alarm.com endpoints
 - Locks
   - Lock/Unlock switch
 - Garage Doors
-  - Open/Close switch
+  - Open/Close switch 
+- Thermostats 
+  - Set mode Off/Heat/Cool/Auto 
+  - Set desired Heat/Cool temperatures
 
 # Installation
 

--- a/src/_models/Contexts.ts
+++ b/src/_models/Contexts.ts
@@ -72,6 +72,8 @@ export interface ThermostatContext extends BaseContext {
   currentTemperature: CharacteristicValue,
   targetTemperature: CharacteristicValue,
   thermostatType: string,
+  supportsHumidity: boolean,
+  humidityLevel: CharacteristicValue,
 }
 
 // Region: Function Casts

--- a/src/_models/Contexts.ts
+++ b/src/_models/Contexts.ts
@@ -64,6 +64,16 @@ export interface GarageContext extends BaseContext {
   garageType: string;
 }
 
+export interface ThermostatContext extends BaseContext {
+  accID: string,
+  name: string,
+  state: CharacteristicValue,
+  desiredState: CharacteristicValue,
+  currentTemperature: CharacteristicValue,
+  targetTemperature: CharacteristicValue,
+  thermostatType: string,
+}
+
 // Region: Function Casts
 
 export function isPartition(accessory: PlatformAccessory): accessory is PlatformAccessory<PartitionContext> {
@@ -80,6 +90,9 @@ export function isLight(accessory: PlatformAccessory): accessory is PlatformAcce
 }
 export function isGarage(accessory: PlatformAccessory): accessory is PlatformAccessory<GarageContext> {
   return (accessory as PlatformAccessory<GarageContext>).context.garageType !== undefined;
+}
+export function isThermostat(accessory: PlatformAccessory): accessory is PlatformAccessory<ThermostatContext> {
+  return (accessory as PlatformAccessory<ThermostatContext>).context.thermostatType !== undefined;
 }
 
 // End Region


### PR DESCRIPTION
Adds in thermostat support for #18. Requires https://github.com/node-alarm-dot-com/node-alarm-dot-com/pull/31

Everything seems to work on my setup. Code largely copied from `garage` logic. Couple of notes:
* Didn't add humidity support. My thermostat displays current humidity on the device, but I don't see values from it on Alarm.com even though it's in API spec. Not sure if my thermostat just doesn't send the values, or if Alarm.com API does't actually support it, or what.
* Not sure best way to handle C/F. Seems like Homebridge always wants Celsius? Alarm.com is in Fahrenheit (at least for my account). Current method works, but Homebridge UI displays some weird rounding sometimes. Home app on iOS displays nice round numbers though.
* Not sure 'Auto' mode is handled correctly, not an option on my thermostat so hard to test.