### PR TITLE
Fix for night arming option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -665,19 +665,19 @@ class ADCPlatform implements DynamicPlatformPlugin {
         method = armStay;
         opts.noEntryDelay = this.armingModes.stay.noEntryDelay;
         opts.silentArming = this.armingModes.stay.silentArming;
-        opts.silentArming = this.armingModes.stay.nightArming;
+        opts.nightArming = this.armingModes.stay.nightArming;
         break;
       case hapCharacteristic.SecuritySystemTargetState.NIGHT_ARM:
         method = armStay;
         opts.noEntryDelay = this.armingModes.night.noEntryDelay;
         opts.silentArming = this.armingModes.night.silentArming;
-        opts.silentArming = this.armingModes.night.nightArming;
+        opts.nightArming = this.armingModes.night.nightArming;
         break;
       case hapCharacteristic.SecuritySystemTargetState.AWAY_ARM:
         method = armAway;
         opts.noEntryDelay = this.armingModes.away.noEntryDelay;
         opts.silentArming = this.armingModes.away.silentArming;
-        opts.silentArming = this.armingModes.away.nightArming;
+        opts.nightArming = this.armingModes.away.nightArming;
         break;
       case hapCharacteristic.SecuritySystemTargetState.DISARM:
         method = disarm;


### PR DESCRIPTION
There appears to be a typo when changing the state of a partition where the night arming option is not passed through correctly. Instead of the night arming mode in the configuration being mapped to the night arming option passed through to alarm.com, it's mapped to the silent arming option, which would mean 1) the night arming option isn't actually ever set and 2) the silent arming option is being overwritten.