### PR TITLE
Add manual system ID fallback and improve Alarm.com auth error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This is a plugin for Homebridge, allowing communication with Alarm.com endpoints
   "password": "<YOUR ALARM.COM PASSWORD>",
   "useMFA": true,
   "mfaCookie": "<USE INSTRUCTIONS IN THE WIKI>",
+  "systemIds": ["8540160"],
   "logLevel": 4,
   "authTimeoutMinutes": 10,
   "pollTimeoutSeconds": 30,
@@ -87,6 +88,7 @@ This is a plugin for Homebridge, allowing communication with Alarm.com endpoints
 - `password`: Alarm.com login password, same as app (required)
 - `useMFA`: boolean indicating if your account requires MFA (required)
 - `mfaCookie`: MFA cookie to be sent with your API requests. Only needed if "useMFA" is set to `true`
+- `systemIds`: Optional array of Alarm.com system IDs. If configured, the plugin skips `/web/api/identities` and uses these IDs directly. This is intended as a workaround for `403 NotAllowed` responses from the identities endpoint.
 - `armingModes`: Object of objects with arming mode options of boolean choices (**WARNING:** the Alarm.com webAPI does not support setting silent arming to true and this feature does not work at this time)
 - `authTimeoutMinutes`: Timeout to Re-Authenticate session (**WARNING:** choosing a time less than 10 minutes could possibly ban/disable your account from Alarm.com)
 - `pollTimeoutSeconds`: Device polling interval (**WARNING:** choosing a time less than 60 seconds could possibly ban/disable your account from Alarm.com)
@@ -97,6 +99,8 @@ This is a plugin for Homebridge, allowing communication with Alarm.com endpoints
   - **3 = GENERAL NOTICES, ERRORS and WARNINGS (default)**
   - 4 = VERBOSE (everything including development output, this also generates a file `ADC-SystemStates.json` with the payload details from Alarm.com in the same folder as the Homebridge config.json file)
 - `ignoredDevices`: An array of IDs for Alarm.com accessories you wish to hide in Homekit
+
+When `systemIds` is configured, the plugin derives the AJAX key from the configured cookie string (`cookie` or `mfaCookie`) and bypasses the identities lookup during login and account-settings fetch.
 
 # Troubleshooting
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -49,6 +49,16 @@
           "functionBody": "return model.useMFA === true"
         }
       },
+      "systemIds": {
+        "title": "Manual System IDs",
+        "description": "Optional Alarm.com system IDs to use instead of /web/api/identities. Use this if Alarm.com returns 403 NotAllowed for identities.",
+        "type": "array",
+        "items": {
+          "title": "System ID",
+          "type": "string",
+          "placeholder": "8540160"
+        }
+      },
       "logLevel": {
         "title": "<b>Log Level</b>",
         "type": "integer",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from 'homebridge';
 
 import fs from 'fs';
+import { inspect } from 'util';
 
 import {
   GARAGE_STATES,
@@ -84,6 +85,17 @@ let platformAccessory: typeof PlatformAccessory;
 let hapService: HAP['Service'];
 let hapCharacteristic: HAP['Characteristic'];
 let uuidGen: typeof import('hap-nodejs/dist/lib/util/uuid');
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+
+  return inspect(error, {
+    depth: 6,
+    breakLength: 120
+  });
+}
 
 export = (api: API): void => {
   hap = api.hap;
@@ -332,20 +344,33 @@ class ADCPlatform implements DynamicPlatformPlugin {
     const now = +new Date();
     if (now > this.authOpts.expires) {
       this.log.debug(`Logging into Alarm.com as ${this.config.username}`);
-      //const authOpts = await login(this.config.username, this.config.password, this.mfaToken);
-      await login(this.config.username, this.config.password, this.useMFA ? this.mfaToken : null)
-        .then((authOpts) => {
-          // Cache login response and estimated expiration time
-          authOpts.expires = +new Date() + 1000 * 60 * this.config.authTimeoutMinutes;
-          this.authOpts = authOpts;
-          this.log.debug(`Logged into Alarm.com as ${this.config.username}`);
-        })
-        .catch((err) => {
-          this.log.error(`loginSession Error: ${err.message}`);
-          this.log.info('Refreshing session authentication.');
-          this.authOpts.expires = +new Date() - 1000 * 60 * this.config.authTimeoutMinutes; // set to the past to trigger refresh
-        });
+      try {
+        const authOpts = await login(
+          this.config.username,
+          this.config.password,
+          this.useMFA ? this.mfaToken : null
+        );
+
+        authOpts.expires = +new Date() + 1000 * 60 * this.config.authTimeoutMinutes;
+        this.authOpts = authOpts;
+        this.log.debug(`Logged into Alarm.com as ${this.config.username}`);
+        this.log.debug(
+          `Alarm.com auth state: ajaxKey=${Boolean(authOpts.ajaxKey)}, systems=${Array.isArray(authOpts.systems) ? authOpts.systems.length : 'invalid'}`
+        );
+      } catch (err) {
+        this.log.error(`loginSession Error: ${describeError(err)}`);
+        this.log.info('Refreshing session authentication.');
+        this.authOpts.expires = +new Date() - 1000 * 60 * this.config.authTimeoutMinutes;
+        throw err;
+      }
     }
+
+    if (!Array.isArray(this.authOpts.systems)) {
+      throw new Error(
+        `Alarm.com login returned invalid auth state: systems=${inspect(this.authOpts.systems, { depth: 4 })}`
+      );
+    }
+
     return this.authOpts;
   }
 
@@ -383,6 +408,11 @@ class ADCPlatform implements DynamicPlatformPlugin {
     try {
       const authOpts = await this.loginSession();
       const identities = await getIdentitiesState(authOpts.cookie, authOpts.ajaxKey);
+      if (!identities || !Array.isArray(identities.data)) {
+        throw new Error(
+          `Unexpected identities response shape: ${inspect(identities, { depth: 6, breakLength: 120 })}`
+        );
+      }
       const identity = identities.data[0];
       if (identity) {
         this.tempDisplayUnitSetting = identity.attributes.localizeTempUnitsToCelsius
@@ -393,11 +423,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
       this.log.error(
         `There was an error retrieving account settings. Please check that your credentials are correct and restart the plugin.`
       );
-      if (typeof e === typeof String) {
-        this.log.error(e);
-      } else if (e instanceof Error) {
-        this.log.error(e.message);
-      }
+      this.log.error(describeError(e));
     }
   }
 
@@ -524,7 +550,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
         });
       })
       .catch((err) => {
-        this.log.error(`refreshDevices Error: ${err.message}`);
+        this.log.error(`refreshDevices Error: ${describeError(err)}`);
         this.log.info('Refreshing session authentication.');
         this.authOpts.expires = +new Date() - 1000 * 60 * this.config.authTimeoutMinutes; // set to the past to trigger refresh
       });
@@ -1769,6 +1795,12 @@ class ADCPlatform implements DynamicPlatformPlugin {
  *   number, number, number, number]>}  See SystemState.ts for return type.
  */
 async function fetchStateForAllSystems(res: AuthOpts): Promise<FlattenedSystemState[]> {
+  if (!res || !Array.isArray(res.systems)) {
+    throw new Error(
+      `Invalid Alarm.com system list in auth response: ${inspect(res, { depth: 6, breakLength: 120 })}`
+    );
+  }
+
   return Promise.all(res.systems.map((id: string) => getCurrentState(id, res)));
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
   private ignoredDevices: string[];
   private useMFA: boolean;
   private mfaToken?: string;
+  private manualSystemIds: string[];
   private tempDisplayUnitSetting: number;
 
   /**
@@ -140,6 +141,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
     this.ignoredDevices = this.config.ignoredDevices ?? [];
     this.useMFA = this.config.useMFA ?? false;
     this.mfaToken = this.config.useMFA ? this.config.mfaCookie : null;
+    this.manualSystemIds = this.getManualSystemIds();
     this.tempDisplayUnitSetting = hapCharacteristic.TemperatureDisplayUnits.CELSIUS;
 
     this.config.authTimeoutMinutes = this.config.authTimeoutMinutes ?? AUTH_TIMEOUT_MINS;
@@ -343,6 +345,16 @@ class ADCPlatform implements DynamicPlatformPlugin {
   async loginSession(): Promise<AuthOpts> {
     const now = +new Date();
     if (now > this.authOpts.expires) {
+      const manualAuthOpts = this.buildManualAuthOpts();
+      if (manualAuthOpts) {
+        manualAuthOpts.expires = +new Date() + 1000 * 60 * this.config.authTimeoutMinutes;
+        this.authOpts = manualAuthOpts;
+        this.log.debug(
+          `Using manually configured Alarm.com system IDs: ${this.manualSystemIds.join(', ')}`
+        );
+        return this.authOpts;
+      }
+
       this.log.debug(`Logging into Alarm.com as ${this.config.username}`);
       try {
         const authOpts = await login(
@@ -405,6 +417,11 @@ class ADCPlatform implements DynamicPlatformPlugin {
    * This method makes a call to alarm.com in order to retrieve global account information.
    */
   async getAccountSettings() {
+    if (this.manualSystemIds.length > 0) {
+      this.log.debug('Skipping account settings lookup because manual system IDs are configured.');
+      return;
+    }
+
     try {
       const authOpts = await this.loginSession();
       const identities = await getIdentitiesState(authOpts.cookie, authOpts.ajaxKey);
@@ -425,6 +442,66 @@ class ADCPlatform implements DynamicPlatformPlugin {
       );
       this.log.error(describeError(e));
     }
+  }
+
+  private getManualSystemIds(): string[] {
+    const configured = this.config.systemIds;
+    if (!Array.isArray(configured)) {
+      return [];
+    }
+
+    return configured
+      .map((value) => String(value).trim())
+      .filter((value) => value.length > 0);
+  }
+
+  private getConfiguredCookieString(): string | null {
+    const cookieValue = this.config.cookie ?? this.config.mfaCookie;
+    if (typeof cookieValue !== 'string') {
+      return null;
+    }
+
+    const trimmed = cookieValue.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private extractAjaxKeyFromCookie(cookieString: string): string | null {
+    const match = /(?:^|;\s*)afg=([^;]+)/.exec(cookieString);
+    return match ? match[1] : null;
+  }
+
+  private buildManualAuthOpts(): AuthOpts | null {
+    if (this.manualSystemIds.length === 0) {
+      return null;
+    }
+
+    const cookie = this.getConfiguredCookieString();
+    if (!cookie) {
+      this.log.error(
+        'Manual system IDs are configured, but no cookie string was found in the plugin config.'
+      );
+      return null;
+    }
+
+    const ajaxKey = this.extractAjaxKeyFromCookie(cookie);
+    if (!ajaxKey) {
+      this.log.error(
+        'Manual system IDs are configured, but the cookie string does not contain an afg cookie.'
+      );
+      return null;
+    }
+
+    return {
+      cookie,
+      ajaxKey,
+      systems: this.manualSystemIds,
+      identities: {
+        data: [],
+        included: [],
+        meta: {}
+      },
+      expires: +new Date() - 1
+    } as AuthOpts;
   }
 
   /**


### PR DESCRIPTION
This change addresses two current failure modes with Alarm.com:

  1. Alarm.com may return 403 NotAllowed for GET /web/api/identities, which prevents the plugin from discovering systems during login.
  2. When auth/session bootstrapping fails, the plugin currently swallows the login failure, continues with invalid auth state, and later crashes on .map(...) against undefined.

  What this changes:

  - adds optional systemIds config support
  - when systemIds is configured, bypasses /web/api/identities and uses the configured system IDs directly
  - derives ajaxKey from the configured cookie string for the manual-system-ID path
  - skips account-settings lookup when manual systemIds are configured, because that also depends on identities
  - improves error logging/serialization so object-shaped failures are surfaced clearly
  - adds guards around invalid auth state so the plugin fails with a useful error instead of crashing on res.systems.map(...)

  Why:

  - Alarm.com is currently returning 403 NotAllowed for the identities endpoint in some real-world sessions
  - this allows the plugin to continue working when the system ID is already known
  - it also makes debugging auth failures materially easier

  Config example:

  {
    "platform": "Alarmdotcom",
    "name": "Security System",
    "username": "user@example.com",
    "password": "secret",
    "useMFA": true,
    "mfaCookie": "<full cookie string>",
    "systemIds": ["8940860"]
  }

  Notes:

  - systemIds is optional and only used as a fallback/workaround path
  - existing behavior remains unchanged when systemIds is not configured