### PR TITLE
fix: correct 7 reliability bugs in existing code

### DIFF
--- a/src/CustomLogger.ts
+++ b/src/CustomLogger.ts
@@ -15,7 +15,7 @@ export class CustomLogger implements Logger {
     this.logLevel = logLevel;
   }
   success(message: string, ...parameters: unknown[]): void {
-    this.debug(message, parameters);
+    this.debug(message, ...parameters);
   }
 
   info(message: string, ...parameters: unknown[]): void {
@@ -43,16 +43,16 @@ export class CustomLogger implements Logger {
   log(level: LogLevel, message: string, ...parameters: unknown[]): void {
     switch (level) {
       case LogLevel.DEBUG:
-        this.debug(message, parameters);
+        this.debug(message, ...parameters);
         break;
       case LogLevel.ERROR:
-        this.error(message, parameters);
+        this.error(message, ...parameters);
         break;
       case LogLevel.INFO:
-        this.info(message, parameters);
+        this.info(message, ...parameters);
         break;
       case LogLevel.WARN:
-        this.warn(message, parameters);
+        this.warn(message, ...parameters);
         break;
       default:
         break;

--- a/src/_models/SimplifiedSystemState.ts
+++ b/src/_models/SimplifiedSystemState.ts
@@ -3,7 +3,8 @@ import {
   LightState,
   LockState,
   PartitionState,
-  SensorState
+  SensorState,
+  ThermostatState
 } from 'node-alarm-dot-com';
 
 export interface SimplifiedSystemState {
@@ -12,4 +13,5 @@ export interface SimplifiedSystemState {
   lights: LightState[],
   locks: LockState[],
   garages: GarageState[],
+  thermostats: ThermostatState[],
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -393,7 +393,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
       this.log.error(
         `There was an error retrieving account settings. Please check that your credentials are correct and restart the plugin.`
       );
-      if (typeof e === typeof String) {
+      if (typeof e === 'string') {
         this.log.error(e);
       } else if (e instanceof Error) {
         this.log.error(e.message);
@@ -965,9 +965,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
       accessory.getService(hapService.Lightbulb).updateCharacteristic(hapCharacteristic.Brightness, newBrightness);
     }
 
-    if (callback !== null) {
-      callback();
-    }
+    callback?.();
   }
 
   /**
@@ -1565,7 +1563,9 @@ class ADCPlatform implements DynamicPlatformPlugin {
     }
 
     if (accessory.context.supportsHumidity && humidityLevel !== accessory.context.humidityLevel) {
-      this.log.info(`Updating thermostat ${name} (${id}), humidity=${humidityLevel}, prev=${accessory.context.state}`);
+      this.log.info(
+        `Updating thermostat ${name} (${id}), humidity=${humidityLevel}, prev=${accessory.context.humidityLevel}`
+      );
 
       accessory.context.humidityLevel = humidityLevel;
 
@@ -1606,6 +1606,11 @@ class ADCPlatform implements DynamicPlatformPlugin {
       case hapCharacteristic.CurrentHeatingCoolingState.OFF:
         newState = THERMOSTAT_STATES.OFF;
         break;
+      default: {
+        const msg = `Can't set thermostat to unknown value ${value}`;
+        this.log.warn(msg);
+        return callback(new Error(msg));
+      }
     }
 
     await this.loginSession()
@@ -1679,18 +1684,19 @@ class ADCPlatform implements DynamicPlatformPlugin {
   addAccessory(accessory: PlatformAccessory<BaseContext>, type: typeof hapService, model: string): void {
     const id = accessory.context.accID;
     const name = accessory.context.name;
-    this.accessories.push(accessory);
+    if (this.accessories.findIndex((a) => a.context.accID === id) > -1) {
+      this.log.warn(`Preventing adding existing ${model} ${name} with id ${id}`);
+      return;
+    }
+
     const serviceUUID = uuidGen.generate(id + type);
 
     // Setup HomeKit service
     accessory.addService(type, name, serviceUUID);
 
     // Register new accessory in HomeKit
-    if (this.accessories.findIndex((accessory) => accessory.context.accID === id) > -1) {
-      this.api.registerPlatformAccessories(PLUGIN_ID, PLUGIN_NAME, [accessory]);
-    } else {
-      this.log.warn(`Preventing adding existing ${model} ${name} with id ${id}`);
-    }
+    this.accessories.push(accessory);
+    this.api.registerPlatformAccessories(PLUGIN_ID, PLUGIN_NAME, [accessory]);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes 7 bugs in existing code that can cause runtime exceptions, silent failures, or incorrect behavior. Every fix corrects existing intent — no behavior changes on working paths.

### Bugs fixed

1. **Dead error branch in `getAccountSettings`** — `typeof e === typeof String` evaluates to `typeof e === 'function'`, never matching string throws. Changed to `typeof e === 'string'`.
2. **`statLightState` crash on undefined callback** — `callback !== null` passes when callback is `undefined`, then throws `TypeError`. Changed to `callback?.()`.
3. **`changeThermostatState` sends `undefined` to API** — No `default` case in switch, so unhandled values (e.g. AUTO) leave `newState` as `undefined`. Added default with error callback.
4. **`addAccessory` duplicate check never triggers** — Accessory was pushed to array *before* the `findIndex` check, so it always found itself. Moved check before push.
5. **Humidity log prints wrong field** — Logged `accessory.context.state` instead of `accessory.context.humidityLevel` for the previous humidity value.
6. **`CustomLogger.log()` and `success()` corrupt parameters** — Passed rest params as a single array instead of spreading. Format strings with `%s`/`%d` wouldn't interpolate correctly.
7. **`SimplifiedSystemState` missing `thermostats`** — Interface omitted `thermostats` field that `listDevices()` actually populates at runtime.

## Test plan

- [ ] Build passes (`tsc --noEmit`)
- [ ] Lint passes (`eslint src/**.ts`)
- [ ] Verify thermostat state changes still work (HEAT, COOL, OFF)
- [ ] Verify light on/off from polling path (callback=null) still works
- [ ] Verify new device discovery registers accessories correctly
- [ ] Verify error logging outputs correctly on login failure