### PR TITLE
chore: remove dead code and unused dependency

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,0 @@
-{
-    "esversion": 6,
-    "asi": true,
-    "-W014": true
-}

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "homebridge": "^1.6.0 || ^2.0.0-beta.0"
   },
   "dependencies": {
-    "node-alarm-dot-com": "2.1.1",
-    "polling-to-event": "^2.1.0"
+    "node-alarm-dot-com": "2.1.1"
   },
   "devDependencies": {
     "@types/node": "^20.8.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,8 +71,6 @@ import {
 import { SimplifiedSystemState } from './_models/SimplifiedSystemState';
 import { CustomLogger, CustomLogLevel } from './CustomLogger';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-let hap: HAP;
 const PLUGIN_ID = 'homebridge-node-alarm-dot-com';
 const PLUGIN_NAME = 'Alarmdotcom';
 const MANUFACTURER = 'Alarm.com';
@@ -86,7 +84,6 @@ let hapCharacteristic: HAP['Characteristic'];
 let uuidGen: typeof import('hap-nodejs/dist/lib/util/uuid');
 
 export = (api: API): void => {
-  hap = api.hap;
   platformAccessory = api.platformAccessory;
   hapService = api.hap.Service;
   hapCharacteristic = api.hap.Characteristic;
@@ -1706,14 +1703,6 @@ class ADCPlatform implements DynamicPlatformPlugin {
     this.log.info(`Removing ${accessory.context.name} (${accessory.context.accID}) from HomeBridge`);
     this.api.unregisterPlatformAccessories(PLUGIN_ID, PLUGIN_NAME, [accessory]);
     this.accessories.splice(this.accessories.indexOf(accessory), 1);
-  }
-
-  /**
-   * Removes all accessories from the platform, homebridge and HomeKit.
-   * Useful for updating homebridge with the list of accessories present.
-   */
-  removeAccessories(): void {
-    this.accessories.forEach((accessory) => this.removeAccessory(accessory));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Remove `polling-to-event` from dependencies — never imported anywhere in source
- Remove `.jshintrc` — legacy JSHint config, irrelevant for TypeScript project
- Remove unused `hap` module-scope variable and its `eslint-disable` comment
- Remove dead `removeAccessories()` method — defined in 2020 TypeScript conversion but never called

## Test plan

- [ ] Build passes (`tsc --noEmit`)
- [ ] Lint passes (`eslint src/**.ts`)
- [ ] Plugin starts and discovers devices normally (no runtime references to removed code)