### PR TITLE
fix: security hardening for config schema, debug output, and file permissions

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -93,7 +93,6 @@
         "title": "Ignored Devices",
         "description": "IDs for Alarm.com accessories you wish to hide in Homekit.",
         "type": "array",
-        "maxItems": 0,
         "items": {
           "title": "Ignored Device",
           "type": "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,8 +218,11 @@ class ADCPlatform implements DynamicPlatformPlugin {
 
     this.listDevices()
       .then((res) => {
-        this.log.debug('Registering system:');
-        this.log.debug(JSON.stringify(res));
+        this.log.debug(
+          `Registering system: ${res.partitions?.length ?? 0} partitions, ${res.sensors?.length ?? 0} sensors, ` +
+            `${res.lights?.length ?? 0} lights, ${res.locks?.length ?? 0} locks, ` +
+            `${res.garages?.length ?? 0} garages`
+        );
 
         for (const device in res) {
           if (device === 'partitions' && typeof res[device][0] === 'undefined') {
@@ -1745,7 +1748,8 @@ class ADCPlatform implements DynamicPlatformPlugin {
             payloadLogPath + payloadLogName,
             payload,
             {
-              flag: 'w+'
+              flag: 'w+',
+              mode: 0o600
             },
             (err) => {
               if (err) {


### PR DESCRIPTION
## Summary

- **Fix `ignoredDevices` config schema** — `maxItems: 0` prevented users from adding any ignored device IDs via Config UI X. The feature was effectively broken through the UI.
- **Restrict debug payload file permissions** — `ADC-SystemStates.json` (written at verbose log level) now uses mode `0o600` (owner read/write only) instead of default umask permissions.
- **Summarize system state in debug log** — Replace `JSON.stringify` of entire device tree with a device count summary. Prevents leaking full system topology (device IDs, names, structure) when logs are forwarded to external services.

## Test plan

- [ ] Build passes (`tsc --noEmit`)
- [ ] Lint passes (`eslint src/**.ts`)
- [ ] Verify `ignoredDevices` can be added via Homebridge Config UI X
- [ ] Verify debug log shows device count summary (e.g. "3 partitions, 12 sensors, 4 lights...")
- [ ] Verify `ADC-SystemStates.json` is created with restricted permissions at verbose log level