### PR TITLE
Fix bug in Celsius/Fahrenheit conversions

### DIFF
--- a/src/handlers/ThermostatHandler.ts
+++ b/src/handlers/ThermostatHandler.ts
@@ -343,7 +343,7 @@ function getThermostatTargetTemperature(thermostat: ThermostatState, convertToC:
 }
 
 function convertFtoC(f: number): number {
-  return Math.round((5 / 9) * (f - 32));
+  return Math.round((((f - 32) * 5) / 9) * 2) / 2;
 }
 
 function convertCtoF(c: number): number {


### PR DESCRIPTION
The previous formula lost the 0.5ºC resolution when converting F -> C, which meant that converting back from C -> F would show a different temp than the user desired. Examples were 62º and 71º. 