### PR TITLE
fix: stop inventing contact state on OpenedClosed WebSocket events

### DIFF
--- a/src/handlers/SensorHandler.ts
+++ b/src/handlers/SensorHandler.ts
@@ -108,14 +108,23 @@ export class SensorHandler extends BaseHandler<SensorContext, SensorState, WebSo
       return false;
     }
 
-    if (eventType === WebSocketEventTypes.OpenedClosed) {
-      this.setContactState(accessory, service, true);
-      setTimeout(() => this.setContactState(accessory, service, false), 1000);
-    } else {
-      this.setContactState(accessory, service, eventType === WebSocketEventTypes.Opened);
+    switch (eventType) {
+      case WebSocketEventTypes.Opened:
+      case WebSocketEventTypes.DoorLeftOpen:
+        this.setContactState(accessory, service, true);
+        return true;
+      case WebSocketEventTypes.Closed:
+      case WebSocketEventTypes.DoorLeftOpenRestoral:
+      case WebSocketEventTypes.OpenedClosed:
+        // OpenedClosed is a completed open→close cycle; final state is closed.
+        // Do not invent a timed open→close pulse — that fights real Opened events
+        // and can report a door closed while it is still open.
+        this.setContactState(accessory, service, false);
+        return true;
+      default:
+        // Tamper/Bypass/etc. are not reliable contact-state signals; fall back to REST.
+        return false;
     }
-
-    return true;
   }
 
   private setContactState(accessory: PlatformAccessory<SensorContext>, service: Service, isOpen: boolean): void {


### PR DESCRIPTION
## Summary
- Remove the synthetic 1-second open→close pulse for `OpenedClosed` WebSocket events; treat that event as a completed cycle and settle contact sensors on closed.
- Map only clear contact signals (`Opened` / `DoorLeftOpen` → open, `Closed` / `DoorLeftOpenRestoral` / `OpenedClosed` → closed).
- Return `false` for tamper/bypass/other sensor events so REST refresh can reconcile state instead of forcing closed.

This matches production logs where contact sensors flipped open then closed one second later via the WebSocket path.

## Example logs (sanitized)

Observed on v1.13.0. Names/IDs redacted.

REST path includes the model name:

```text
[Security] Updating sensor Front Door (Contact Sensor) (00000000-1), state=0, prev=1
```

WebSocket path omits the model and pulses open→closed ~1s later (matches the `OpenedClosed` `setTimeout(..., 1000)` behavior):

```text
[Security] Updating sensor Side Door (00000000-11), state=1, prev=0
[Security] Updating sensor Side Door (00000000-11), state=0, prev=1
[Security] Updating sensor Side Door (00000000-11), state=1, prev=0
[Security] Updating sensor Side Door (00000000-11), state=0, prev=1
```

## Test plan
- [ ] Open a door and confirm HomeKit shows open on `Opened` (stays open until closed)
- [ ] Close a door and confirm HomeKit shows closed on `Closed`
- [ ] Walk through a door that emits `OpenedClosed` and confirm it ends closed without a forced 1s pulse over a still-open door
- [ ] Confirm tamper/bypass no longer forces contact closed; REST fallback still updates
- [ ] Check logs no longer show paired `state=1` then `state=0` one second later from the WS path for the same accessory