### PR TITLE
fix: allow configuring ignoredDevices in Config UI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -96,7 +96,6 @@
         "title": "Ignored Devices",
         "description": "IDs for Alarm.com accessories you wish to hide in HomeKit.",
         "type": "array",
-        "maxItems": 0,
         "items": {
           "title": "Ignored Device",
           "type": "string",


### PR DESCRIPTION
## Summary
- Remove `maxItems: 0` from the `ignoredDevices` config schema entry so Homebridge Config UI X can add device IDs to ignore.

Runtime already supports `ignoredDevices`; this was a schema-only UI bug.

## Test plan
- [ ] Open the plugin settings in Homebridge Config UI X
- [ ] Confirm you can add one or more Ignored Devices entries
- [ ] Save config and restart; ignored accessories stay hidden as before