### PR TITLE
Expose Alarm.com doorbells as motion sensors only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to this project are documented in this file, based on the
 
 ### Bugs Squished
 
-- Fixed regular cameras being exposed to HomeKit as doorbells and generating false doorbell notifications. Cached
-  camera accessories created by version 1.13.0 are removed automatically.
+- Removed the HomeKit Doorbell service and ring events from Alarm.com cameras while retaining motion notifications.
+  Regular cameras are no longer exposed, and cached Doorbell services created by version 1.13.0 are removed
+  automatically.
 
 ## [1.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project are documented in this file, based on the
 [GitHub releases](https://github.com/node-alarm-dot-com/homebridge-node-alarm-dot-com/releases).
 
+## Unreleased
+
+### Bugs Squished
+
+- Fixed regular cameras being exposed to HomeKit as doorbells and generating false doorbell notifications. Cached
+  camera accessories created by version 1.13.0 are removed automatically.
+
 ## [1.13.0]
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ This is a plugin for Homebridge, allowing communication with Alarm.com endpoints
   - Set desired Heat/Cool temperatures
   - View humidity
 - Doorbells
-  - Doorbells appear as a motion sensor for notifications only. Video/audio is not supported
+  - Alarm.com doorbell cameras appear only as motion sensors. The HomeKit Doorbell service, video, and audio are not
+    supported.
   - The ADC-VDB750 is supported by default. Other camera models are only exposed when Alarm.com identifies them as
     doorbells and `supportAnyDoorbellCamera` is enabled.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This is a plugin for Homebridge, allowing communication with Alarm.com endpoints
   - View humidity
 - Doorbells
   - Doorbells appear as a motion sensor for notifications only. Video/audio is not supported
+  - The ADC-VDB750 is supported by default. Other camera models are only exposed when Alarm.com identifies them as
+    doorbells and `supportAnyDoorbellCamera` is enabled.
 
 # Installation
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -106,7 +106,7 @@
       "supportAnyDoorbellCamera": {
         "title": "<b>Support Any Doorbell Camera</b>",
         "type": "boolean",
-        "description": "When enabled, any camera where isDoorbellCamera is true will be registered as a doorbell in HomeKit, in addition to the ADC-VDB750 which is always supported."
+        "description": "When enabled, any camera where isDoorbellCamera is true will be registered as a motion sensor in HomeKit, in addition to the ADC-VDB750 which is always supported."
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start": "ts-node src/index.ts",
     "start-dev": "homebridge -I -D",
     "watch": "npm run build && npm link && tsc && homebridge -I -D",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run build && node --test test/*.test.js"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/src/_models/Contexts.ts
+++ b/src/_models/Contexts.ts
@@ -82,6 +82,7 @@ export interface DoorbellContext extends BaseContext {
   accID: string;
   name: string;
   model: string;
+  isDoorbellCamera?: boolean;
   motionDetected: boolean;
   doorbellType: 'default';
 }

--- a/src/handlers/DoorbellHandler.ts
+++ b/src/handlers/DoorbellHandler.ts
@@ -1,8 +1,22 @@
 import { CharacteristicGetCallback, PlatformAccessory } from 'homebridge';
 import { CameraState, WebSocketEventTypes } from 'node-alarm-dot-com';
-import { DoorbellContext } from '../_models/Contexts';
+import { DoorbellContext, isDoorbell } from '../_models/Contexts';
 import { BaseHandler } from './BaseHandler';
 import { HandlerContext } from './HandlerContext';
+
+type DoorbellCamera = {
+  attributes: {
+    deviceModel: string;
+    isDoorbellCamera?: boolean;
+  };
+};
+
+export function isSupportedDoorbellCamera(camera: DoorbellCamera, supportAnyDoorbellCamera: boolean): boolean {
+  return (
+    camera.attributes.deviceModel === 'ADC-VDB750' ||
+    (supportAnyDoorbellCamera && camera.attributes.isDoorbellCamera === true)
+  );
+}
 
 export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, WebSocketEventTypes> {
   constructor(ctx: HandlerContext) {
@@ -11,6 +25,10 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
 
   add(camera: CameraState): void {
     const { api, log, ignoredDevices } = this.ctx;
+    if (!isSupportedDoorbellCamera(camera, this.ctx.supportAnyDoorbellCamera)) {
+      return;
+    }
+
     const hap = api.hap;
     const id = camera.id;
     const model = camera.attributes.deviceModel;
@@ -21,6 +39,7 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
       accID: id,
       name: name,
       model: model,
+      isDoorbellCamera: camera.attributes.isDoorbellCamera,
       motionDetected: false,
       doorbellType: 'default'
     };
@@ -32,6 +51,18 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
       this.setup(accessory);
       this.stat(accessory, camera);
     }
+  }
+
+  override refresh(camera: CameraState): void {
+    const accessory = this.ctx.accessories.find((a) => a.context.accID === camera.id);
+    if (!isSupportedDoorbellCamera(camera, this.ctx.supportAnyDoorbellCamera)) {
+      if (accessory && isDoorbell(accessory)) {
+        this.ctx.removeAccessory(accessory);
+      }
+      return;
+    }
+
+    super.refresh(camera);
   }
 
   setup(accessory: PlatformAccessory<DoorbellContext>): void {
@@ -63,11 +94,14 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
       .on('get', (callback: CharacteristicGetCallback) => callback(null, accessory.context.motionDetected));
   }
 
-  stat(accessory: PlatformAccessory<DoorbellContext>, _camera: CameraState): void {
+  stat(accessory: PlatformAccessory<DoorbellContext>, camera: CameraState): void {
     const { api, log } = this.ctx;
     const hap = api.hap;
     const id = accessory.context.accID;
     const name = accessory.context.name;
+
+    accessory.context.model = camera.attributes.deviceModel;
+    accessory.context.isDoorbellCamera = camera.attributes.isDoorbellCamera;
 
     log.debug(`Polling doorbell ${name} (${id})`);
 
@@ -79,6 +113,16 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
   }
 
   statFromWebSocket(accessory: PlatformAccessory<DoorbellContext>, eventType: WebSocketEventTypes): boolean {
+    const camera = {
+      attributes: {
+        deviceModel: accessory.context.model,
+        isDoorbellCamera: accessory.context.isDoorbellCamera
+      }
+    };
+    if (!isSupportedDoorbellCamera(camera, this.ctx.supportAnyDoorbellCamera)) {
+      return false;
+    }
+
     const { api, log } = this.ctx;
     const hap = api.hap;
     const id = accessory.context.accID;

--- a/src/handlers/DoorbellHandler.ts
+++ b/src/handlers/DoorbellHandler.ts
@@ -46,8 +46,7 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
 
     if (!ignoredDevices.includes(id)) {
       log.info(`Adding ${model} "${name}" (id=${id}, uuid=${accessory.UUID})`);
-      this.ctx.addAccessory(accessory, hap.Service.Doorbell, model);
-      accessory.addService(hap.Service.MotionSensor);
+      this.ctx.addAccessory(accessory, hap.Service.MotionSensor, model);
       this.setup(accessory);
       this.stat(accessory, camera);
     }
@@ -74,14 +73,10 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
     this.registerIdentify(accessory);
 
     const doorbellService = accessory.getService(hap.Service.Doorbell);
-    if (doorbellService === undefined) {
-      log.error(`Trouble getting Doorbell service for ${accessory.context.accID}`);
-      return;
+    if (doorbellService !== undefined) {
+      log.info(`Removing legacy Doorbell service from ${accessory.context.name} (${accessory.context.accID})`);
+      accessory.removeService(doorbellService);
     }
-
-    doorbellService
-      .getCharacteristic(hap.Characteristic.ProgrammableSwitchEvent)
-      .on('get', (callback: CharacteristicGetCallback) => callback(null, null));
 
     const motionService = accessory.getService(hap.Service.MotionSensor);
     if (motionService === undefined) {
@@ -103,7 +98,7 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
     accessory.context.model = camera.attributes.deviceModel;
     accessory.context.isDoorbellCamera = camera.attributes.isDoorbellCamera;
 
-    log.debug(`Polling doorbell ${name} (${id})`);
+    log.debug(`Polling camera motion sensor ${name} (${id})`);
 
     if (accessory.context.motionDetected) {
       accessory.context.motionDetected = false;
@@ -123,25 +118,16 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
       return false;
     }
 
-    const { api, log } = this.ctx;
-    const hap = api.hap;
-    const id = accessory.context.accID;
-    const name = accessory.context.name;
-
-    if (eventType === WebSocketEventTypes.VideoCameraTriggered) {
-      log.info(`Doorbell ring detected for ${name} (${id})`);
-      const doorbellService = accessory.getService(hap.Service.Doorbell);
-      doorbellService
-        ?.getCharacteristic(hap.Characteristic.ProgrammableSwitchEvent)
-        .updateValue(hap.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
-      return true;
-    }
-
     if (
       eventType === WebSocketEventTypes.VideoAnalyticsDetection ||
       eventType === WebSocketEventTypes.VideoAnalytics2Detection
     ) {
-      log.info(`Motion detected for doorbell ${name} (${id})`);
+      const { api, log } = this.ctx;
+      const hap = api.hap;
+      const id = accessory.context.accID;
+      const name = accessory.context.name;
+
+      log.info(`Motion detected for camera ${name} (${id})`);
       accessory.context.motionDetected = true;
       const motionService = accessory.getService(hap.Service.MotionSensor);
       motionService?.getCharacteristic(hap.Characteristic.MotionDetected).updateValue(true);
@@ -149,7 +135,7 @@ export class DoorbellHandler extends BaseHandler<DoorbellContext, CameraState, W
       setTimeout(() => {
         accessory.context.motionDetected = false;
         motionService?.getCharacteristic(hap.Characteristic.MotionDetected).updateValue(false);
-        log.debug(`Motion reset for doorbell ${name} (${id})`);
+        log.debug(`Motion reset for camera ${name} (${id})`);
       }, 5000);
 
       return true;

--- a/src/handlers/HandlerContext.ts
+++ b/src/handlers/HandlerContext.ts
@@ -13,6 +13,7 @@ export interface HandlerContext {
   readonly ignoredDevices: string[];
   readonly armingModes: ArmingModes;
   readonly tempDisplayUnitSetting: number;
+  readonly supportAnyDoorbellCamera: boolean;
   loginSession(): Promise<AuthOpts>;
   refreshDevices(): Promise<void>;
   addAccessory(accessory: PlatformAccessory<BaseContext>, type: typeof Service, model: string): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
   tempDisplayUnitSetting: number;
   armingModes: ArmingModes;
   ignoredDevices: string[];
+  readonly supportAnyDoorbellCamera: boolean;
   private authTimeoutMinutes: number;
   private pollTimeoutSeconds: number;
   private timerHandle: NodeJS.Timeout | undefined;
@@ -113,6 +114,7 @@ class ADCPlatform implements DynamicPlatformPlugin {
     this.logLevel = this.config.logLevel ?? LOG_LEVEL;
     this.log = new CustomLogger(log, this.logLevel);
     this.ignoredDevices = this.config.ignoredDevices ?? [];
+    this.supportAnyDoorbellCamera = this.config.supportAnyDoorbellCamera ?? false;
     this.useMFA = this.config.useMFA ?? false;
     this.mfaToken = this.config.useMFA ? this.config.mfaCookie : undefined;
     this.tempDisplayUnitSetting = api.hap.Characteristic.TemperatureDisplayUnits.CELSIUS;
@@ -218,12 +220,15 @@ class ADCPlatform implements DynamicPlatformPlugin {
               const deviceType = d.type;
               const realDeviceType = deviceType.split('/')[1];
               if (!this.ignoredDevices.includes(d.id)) {
+                if (key === 'cameras') {
+                  this.doorbellHandler.refresh(d as CameraState);
+                  return;
+                }
+
                 const uuid = this.api.hap.uuid.generate(d.id);
                 const existingAccessory = this.accessories.find((accessory) => accessory.UUID === uuid);
                 if (!existingAccessory) {
-                  if (key === 'cameras') {
-                    this.doorbellHandler.add(d as CameraState);
-                  } else if (realDeviceType === 'partition') {
+                  if (realDeviceType === 'partition') {
                     this.partitionHandler.add(d as PartitionState);
                   } else if (realDeviceType === 'sensor') {
                     this.sensorHandler.add(d as SensorState);

--- a/test/doorbell-handler.test.js
+++ b/test/doorbell-handler.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { DoorbellHandler, isSupportedDoorbellCamera } = require('../dist/handlers/DoorbellHandler');
+
+function camera(deviceModel, isDoorbellCamera, id = 'camera-1') {
+  return {
+    id,
+    attributes: {
+      deviceModel,
+      isDoorbellCamera
+    }
+  };
+}
+
+test('supports the ADC-VDB750 by default', () => {
+  assert.equal(isSupportedDoorbellCamera(camera('ADC-VDB750', false), false), true);
+});
+
+test('does not expose other doorbell cameras unless explicitly enabled', () => {
+  const otherDoorbell = camera('OTHER-DOORBELL', true);
+
+  assert.equal(isSupportedDoorbellCamera(otherDoorbell, false), false);
+  assert.equal(isSupportedDoorbellCamera(otherDoorbell, true), true);
+});
+
+test('does not expose a regular camera even when other doorbell models are enabled', () => {
+  assert.equal(isSupportedDoorbellCamera(camera('ADC-OTHER-CAMERA', false), true), false);
+});
+
+test('removes an unsupported doorbell accessory restored from cache', () => {
+  const cachedAccessory = {
+    context: {
+      accID: 'camera-1',
+      doorbellType: 'default'
+    }
+  };
+  const removed = [];
+  const handler = new DoorbellHandler({
+    accessories: [cachedAccessory],
+    ignoredDevices: [],
+    supportAnyDoorbellCamera: false,
+    removeAccessory(accessory) {
+      removed.push(accessory);
+    }
+  });
+
+  handler.refresh(camera('ADC-OTHER-CAMERA', false));
+
+  assert.deepEqual(removed, [cachedAccessory]);
+});
+
+test('ignores events from an unsupported doorbell accessory restored from cache', () => {
+  const cachedAccessory = {
+    context: {
+      accID: 'camera-1',
+      model: 'ADC-OTHER-CAMERA',
+      doorbellType: 'default'
+    }
+  };
+  const handler = new DoorbellHandler({
+    supportAnyDoorbellCamera: false
+  });
+
+  assert.equal(handler.statFromWebSocket(cachedAccessory, 1), false);
+});

--- a/test/doorbell-handler.test.js
+++ b/test/doorbell-handler.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 
 const { DoorbellHandler, isSupportedDoorbellCamera } = require('../dist/handlers/DoorbellHandler');
+const { WebSocketEventTypes } = require('node-alarm-dot-com');
 
 function camera(deviceModel, isDoorbellCamera, id = 'camera-1') {
   return {
@@ -26,6 +27,79 @@ test('does not expose other doorbell cameras unless explicitly enabled', () => {
 
 test('does not expose a regular camera even when other doorbell models are enabled', () => {
   assert.equal(isSupportedDoorbellCamera(camera('ADC-OTHER-CAMERA', false), true), false);
+});
+
+test('registers a supported camera as a motion sensor without a Doorbell service', () => {
+  const AccessoryInformation = Symbol('AccessoryInformation');
+  const Doorbell = Symbol('Doorbell');
+  const MotionSensor = Symbol('MotionSensor');
+  const MotionDetected = Symbol('MotionDetected');
+  const registeredServices = [];
+
+  class Accessory {
+    constructor(name, uuid) {
+      this.displayName = name;
+      this.UUID = uuid;
+      this.context = {};
+      this.services = new Map();
+    }
+
+    addService(service) {
+      this.services.set(service, {
+        getCharacteristic(characteristic) {
+          assert.equal(characteristic, MotionDetected);
+          return {
+            on() {
+              return this;
+            },
+            updateValue() {}
+          };
+        }
+      });
+    }
+
+    getService(service) {
+      if (service === AccessoryInformation) return undefined;
+      return this.services.get(service);
+    }
+
+    on() {}
+  }
+
+  const handler = new DoorbellHandler({
+    api: {
+      hap: {
+        uuid: { generate: (id) => `uuid:${id}` },
+        Service: { AccessoryInformation, Doorbell, MotionSensor },
+        Characteristic: { MotionDetected }
+      },
+      platformAccessory: Accessory
+    },
+    accessories: [],
+    ignoredDevices: [],
+    supportAnyDoorbellCamera: false,
+    addAccessory(accessory, service) {
+      registeredServices.push(service);
+      accessory.addService(service);
+    },
+    log: {
+      debug() {},
+      error() {},
+      info() {}
+    }
+  });
+
+  handler.add({
+    ...camera('ADC-VDB750', true),
+    attributes: {
+      deviceModel: 'ADC-VDB750',
+      description: 'Front Door',
+      isDoorbellCamera: true
+    }
+  });
+
+  assert.deepEqual(registeredServices, [MotionSensor]);
+  assert.equal(registeredServices.includes(Doorbell), false);
 });
 
 test('removes an unsupported doorbell accessory restored from cache', () => {
@@ -63,4 +137,76 @@ test('ignores events from an unsupported doorbell accessory restored from cache'
   });
 
   assert.equal(handler.statFromWebSocket(cachedAccessory, 1), false);
+});
+
+test('ignores camera-triggered events instead of generating a doorbell ring', () => {
+  const accessory = {
+    context: {
+      accID: 'camera-1',
+      model: 'ADC-VDB750',
+      doorbellType: 'default'
+    }
+  };
+  const handler = new DoorbellHandler({
+    supportAnyDoorbellCamera: false
+  });
+
+  assert.equal(handler.statFromWebSocket(accessory, WebSocketEventTypes.VideoCameraTriggered), false);
+});
+
+test('removes a legacy Doorbell service while restoring the motion sensor', () => {
+  const AccessoryInformation = Symbol('AccessoryInformation');
+  const Doorbell = Symbol('Doorbell');
+  const MotionSensor = Symbol('MotionSensor');
+  const MotionDetected = Symbol('MotionDetected');
+  const doorbellService = {};
+  const motionCharacteristic = {
+    on() {
+      return this;
+    }
+  };
+  const motionService = {
+    getCharacteristic(characteristic) {
+      assert.equal(characteristic, MotionDetected);
+      return motionCharacteristic;
+    }
+  };
+  const removed = [];
+  const accessory = {
+    context: {
+      accID: 'camera-1',
+      name: 'Front Door',
+      model: 'ADC-VDB750',
+      motionDetected: false,
+      doorbellType: 'default'
+    },
+    getService(service) {
+      if (service === Doorbell) return doorbellService;
+      if (service === MotionSensor) return motionService;
+      if (service === AccessoryInformation) return undefined;
+      throw new Error('Unexpected service');
+    },
+    removeService(service) {
+      removed.push(service);
+    },
+    on() {}
+  };
+  const handler = new DoorbellHandler({
+    api: {
+      hap: {
+        Service: { AccessoryInformation, Doorbell, MotionSensor },
+        Characteristic: { MotionDetected }
+      }
+    },
+    log: {
+      debug() {},
+      error() {},
+      info() {}
+    },
+    supportAnyDoorbellCamera: false
+  });
+
+  handler.setup(accessory);
+
+  assert.deepEqual(removed, [doorbellService]);
 });


### PR DESCRIPTION
## Summary

- restore the camera classification gate removed during the 1.13.0 doorbell work
- expose supported Alarm.com doorbell cameras only as HomeKit motion sensors, without a HomeKit Doorbell service
- ignore `VideoCameraTriggered` events while retaining motion from video analytics events
- automatically remove regular cameras and legacy Doorbell services cached by version 1.13.0
- add regression tests and update the user-facing documentation and configuration description

## Root cause and impact

Version 1.13.0 sent every Alarm.com camera through `DoorbellHandler`, which unconditionally added HomeKit's Doorbell service. A generic `VideoCameraTriggered` event from a regular camera could therefore be translated into a HomeKit doorbell press, causing HomePods to chime and Home to report "Someone rang the doorbell."

This update follows the maintainer's requested behavior: supported Alarm.com doorbell cameras provide motion notifications only. The plugin no longer creates a HomeKit Doorbell service or translates camera-trigger events into doorbell presses. Regular cameras are filtered out, and affected cached accessories are migrated automatically without clearing the entire Homebridge cache.

Fixes #173.

## Validation

- `npm test` (build and 8 tests passing)
- `npm run lint`
- `npm pack --dry-run`
- `git diff --check`
